### PR TITLE
Fixed various variable warnings given by Visual Studio

### DIFF
--- a/FEFTwiddler/Data/BaseDatabase.cs
+++ b/FEFTwiddler/Data/BaseDatabase.cs
@@ -107,7 +107,8 @@ namespace FEFTwiddler.Data
                 lsi.SetAttributeValue("byteOffset", byteOffset);
                 lsi.SetAttributeValue("bitMask", bitMask);
             }
-            var breakpoint = true;
+            // This appears to be a useless boolean initiliazization and assignment
+            // var breakpoint = true;
         }
     }
 }

--- a/FEFTwiddler/Form1.cs
+++ b/FEFTwiddler/Form1.cs
@@ -928,7 +928,7 @@ namespace FEFTwiddler
                 Raw.Text = item.Hex();
             }
             catch(ArgumentOutOfRangeException e)
-            { }
+            { Console.WriteLine(e); }
             
             EventsOn();
         }

--- a/FEFTwiddler/Model/ChapterSave.cs
+++ b/FEFTwiddler/Model/ChapterSave.cs
@@ -9,6 +9,8 @@ namespace FEFTwiddler.Model
     /// <summary>
     /// A Fire Emblem Fates "Chapter" save
     /// </summary>
+    /// 
+
     public class ChapterSave : ISave
     {
         #region Member variables
@@ -45,6 +47,7 @@ namespace FEFTwiddler.Model
         #region Properties
 
         public byte[] AvatarName { get; set; }
+        public byte[] chunk { get; set; }
 
         public uint Gold { get; set; }
 
@@ -186,7 +189,7 @@ namespace FEFTwiddler.Model
 
         public void ReadHeaderData(BinaryReader br)
         {
-            byte[] chunk;
+ 
 
             // Stuff
             br.ReadBytes(0x0F);
@@ -206,8 +209,7 @@ namespace FEFTwiddler.Model
 
         public void ReadUserData(BinaryReader br)
         {
-            byte[] chunk;
-
+    
             // Stuff
             br.ReadBytes(0x09);
 
@@ -227,9 +229,7 @@ namespace FEFTwiddler.Model
 
         public void ReadFileData(BinaryReader br)
         {
-            byte[] chunk;
-
-            // Stuff
+              // Stuff
             br.ReadBytes(0x04);
 
             // Ruleset
@@ -261,7 +261,7 @@ namespace FEFTwiddler.Model
 
         public void WriteFileData(BinaryWriter bw)
         {
-            byte[] chunk;
+
 
             bw.BaseStream.Seek(_fileDataOffset, SeekOrigin.Begin);
 
@@ -322,8 +322,6 @@ namespace FEFTwiddler.Model
 
         private void ReadCurrentCharacter(BinaryReader br)
         {
-            byte[] chunk;
-
             var character = new Character();
 
             // To make writing easier
@@ -566,7 +564,7 @@ namespace FEFTwiddler.Model
 
         private void WriteCurrentCharacter(BinaryWriter bw, Model.Character character)
         {
-            byte[] chunk;
+
 
             bw.BaseStream.Seek(character.BinaryPosition, SeekOrigin.Begin);
 
@@ -732,7 +730,6 @@ namespace FEFTwiddler.Model
 
         public void ReadMyCastle(BinaryReader br)
         {
-            byte[] chunk;
 
             // Stuff
             br.ReadBytes(0x6C);
@@ -822,7 +819,7 @@ namespace FEFTwiddler.Model
 
         public void WriteMyCastle(BinaryWriter bw)
         {
-            byte[] chunk;
+
 
             bw.BaseStream.Seek(_myCastleOffset, SeekOrigin.Begin);
 


### PR DESCRIPTION
Title pretty much says it all. I was about to build it from source when Visual Studio gave some warnings about variables. The biggest change is still that I moved `byte[] chunck` from being declared every single method to a public class property so it is only declared once then referenced each time with each method.

I have somewhat tested this but not thoroughly - especially not with the unittests (i assume that's what is inside FEFTwiddlerTest).

To give some feedback on the change in `Form1.cs`:
Using a Try Catch in which the Catch never prints anything anywhere is a waste of said Catch, albeit it being mandatory for TryCatch. Ideally `ArgumentOutOfRangeException e` would be converted to some form of to the end user sensible text and put into a popup box, but since that is beyond the scope of what is really necessary for a save editor like this I have now simply set it to write the error to the Console in case the programmer (you) is running a debug build.